### PR TITLE
Minigames: add nav link + auto-advance the card duel

### DIFF
--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -10,6 +10,7 @@ const MTG_LINKS = [
   { to: "/collection", label: "Collection" },
   { to: "/tournaments", label: "Tournaments" },
   { to: "/deck-analysis", label: "Analysis" },
+  { to: "/minigames", label: "Minigames" },
 ];
 
 const RB_LINKS = [
@@ -18,6 +19,7 @@ const RB_LINKS = [
   { to: "/my-decks", label: "My Decks" },
   { to: "/collection", label: "Collection" },
   { to: "/riftbound/tournaments", label: "Tournaments" },
+  { to: "/minigames", label: "Minigames" },
 ];
 
 const Nav: React.FC = () => {

--- a/frontend/src/pages/minigames/CardDuelPage.tsx
+++ b/frontend/src/pages/minigames/CardDuelPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   fetchDuelLeaderboard,
   fetchDuelPair,
@@ -31,7 +31,15 @@ const CardDuelPage: React.FC = () => {
 
   const accent = game === "riftbound" ? T.purple : T.blue;
 
+  // Delay before auto-loading the next pair so the reveal is visible.
+  const REVEAL_MS = 1600;
+  const advanceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const loadPair = useCallback(async (g: Game, f: string) => {
+    if (advanceTimer.current) {
+      clearTimeout(advanceTimer.current);
+      advanceTimer.current = null;
+    }
     setLoading(true);
     setError(null);
     setResult(null);
@@ -53,6 +61,14 @@ const CardDuelPage: React.FC = () => {
     loadPair(game, format);
   }, [game, format, loadPair]);
 
+  // Clear any pending auto-advance when leaving the page.
+  useEffect(
+    () => () => {
+      if (advanceTimer.current) clearTimeout(advanceTimer.current);
+    },
+    [],
+  );
+
   const switchGame = (g: Game) => {
     if (g === game) return;
     setShowBoard(false);
@@ -69,6 +85,9 @@ const CardDuelPage: React.FC = () => {
     try {
       const res = await voteDuel(game, format, clicked.card_id, other.card_id, getVoterKey());
       setResult(res);
+      // Show the winner briefly, then auto-load the next pair.
+      if (advanceTimer.current) clearTimeout(advanceTimer.current);
+      advanceTimer.current = setTimeout(() => loadPair(game, format), REVEAL_MS);
     } catch (e: any) {
       setError(
         e?.response?.status === 429
@@ -175,14 +194,15 @@ const CardDuelPage: React.FC = () => {
         </div>
       )}
 
-      {/* Reveal + next */}
+      {/* Reveal — auto-advances to the next pair shortly */}
       {result && (
-        <div style={{ textAlign: "center", marginTop: "1.5em" }}>
+        <div style={{ textAlign: "center", marginTop: "1.5em", display: "flex", justifyContent: "center", alignItems: "center", gap: "1em" }}>
+          <span style={{ color: T.textDim, fontSize: "0.9em" }}>Loading next matchup…</span>
           <button
             type="button"
             onClick={() => loadPair(game, format)}
             style={{
-              padding: "0.6em 1.6em",
+              padding: "0.5em 1.3em",
               background: `linear-gradient(to bottom, ${accent}CC, ${accent})`,
               color: T.goldLight,
               border: `1px solid ${T.gold}88`,
@@ -193,7 +213,7 @@ const CardDuelPage: React.FC = () => {
               textTransform: "uppercase",
             }}
           >
-            Next Pair →
+            Next Now →
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary
Two small UX follow-ups to the merged minigames section:

1. **Discoverable nav link** — adds a **Minigames** item to both the MTG and Riftbound sub-navs (`Nav.tsx`). Previously the section was only reachable by typing `/#/minigames` or `/#/minigames/duel`.
2. **Auto-advance the duel** — in `CardDuelPage`, selecting a card now shows the winner reveal (ELO deltas + "STRONGER" highlight) for ~1.6s and then **automatically loads the next pair**. The old manual "Next Pair" button becomes a "Next Now →" skip, with a "Loading next matchup…" hint. Pending timers are cleared on unmount and when the game/format changes.

## Verification
- `tsc --noEmit` clean; `eslint` clean on the changed files (no `react-hooks/exhaustive-deps` issues — only the stable timer ref is referenced inside hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)