### PR TITLE
feat(ads): source AdMob/AdSense IDs from build env with test/no-op fallbacks

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -32,6 +32,8 @@ jobs:
         working-directory: frontend
         env:
           REACT_APP_API_URL: ${{ vars.REACT_APP_API_URL }}
+          # Real AdMob banner unit ID (env: production); empty → Google test banner + test mode
+          REACT_APP_ADMOB_BANNER_ID: ${{ vars.REACT_APP_ADMOB_BANNER_ID }}
           CI: false
         run: |
           npm ci
@@ -56,6 +58,8 @@ jobs:
           # which Play Console requires for every upload.
           VERSION_CODE: ${{ github.run_number }}
           VERSION_NAME: ${{ inputs.version_name }}
+          # Real AdMob App ID (env: production); empty → Google test App ID in the manifest
+          ADMOB_APP_ID: ${{ vars.ADMOB_APP_ID }}
         run: |
           chmod +x gradlew
           ./gradlew bundleRelease

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,6 +109,11 @@ jobs:
         working-directory: frontend
         env:
           REACT_APP_API_URL: ${{ vars.REACT_APP_API_URL }}
+          # AdSense IDs (env: production); empty until the account is approved —
+          # AdSlot renders nothing when unset
+          REACT_APP_ADSENSE_CLIENT: ${{ vars.REACT_APP_ADSENSE_CLIENT }}
+          REACT_APP_ADSENSE_SLOT_LEADERBOARD: ${{ vars.REACT_APP_ADSENSE_SLOT_LEADERBOARD }}
+          REACT_APP_ADSENSE_SLOT_FOOTER: ${{ vars.REACT_APP_ADSENSE_SLOT_FOOTER }}
           CI: false # treat warnings as warnings, not errors
         run: |
           npm ci

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -11,6 +11,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode((System.getenv("VERSION_CODE") ?: "1").toInteger())
         versionName(System.getenv("VERSION_NAME") ?: "1.0")
+        // AdMob App ID for AndroidManifest; defaults to Google's official test App ID
+        manifestPlaceholders = [admobAppId: System.getenv("ADMOB_APP_ID") ?: "ca-app-pub-3940256099942544~3347511713"]
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -9,11 +9,11 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
-        <!-- AdMob App ID — Google's official sample/test App ID. Serves test ads only.
-             Replace with your real ID from admob.google.com before a revenue-bearing release. -->
+        <!-- AdMob App ID — injected by Gradle from the ADMOB_APP_ID env var;
+             defaults to Google's official test App ID (test ads only). -->
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="ca-app-pub-3940256099942544~3347511713"/>
+            android:value="${admobAppId}"/>
 
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density"

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -6,8 +6,8 @@
     <meta name="theme-color" content="#C9A84C" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>TCG Builder</title>
-    <!-- Google AdSense — replace ca-pub-XXXXXXXXXXXXXXXX with your publisher ID -->
-    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
+    <!-- Google AdSense script is injected at runtime by AdSlot.tsx using the
+         REACT_APP_ADSENSE_CLIENT build-time env var. -->
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,7 +26,8 @@ import CardDuelPage from "./pages/minigames/CardDuelPage";
 import PrivacyPolicyPage from "./pages/PrivacyPolicyPage";
 import NotFoundPage from "./pages/NotFoundPage";
 
-const SLOT_ID_LEADERBOARD = "XXXXXXXXXX"; // replace with AdSense leaderboard ad unit slot ID
+// AdSense leaderboard ad-unit slot ID, from the build env; AdSlot renders nothing when unset
+const SLOT_ID_LEADERBOARD = process.env.REACT_APP_ADSENSE_SLOT_LEADERBOARD || "";
 
 const AppInner: React.FC = () => {
   return (

--- a/frontend/src/components/AdSlot.tsx
+++ b/frontend/src/components/AdSlot.tsx
@@ -7,19 +7,35 @@ interface AdSlotProps {
   style?: React.CSSProperties;
 }
 
-const AD_CLIENT = "ca-pub-XXXXXXXXXXXXXXXX"; // replace with your AdSense publisher ID
+// AdSense publisher ID comes from the build env (GHA variable); when unset
+// (dev, forks, pre-approval builds) AdSlot renders nothing.
+const AD_CLIENT = process.env.REACT_APP_ADSENSE_CLIENT || "";
+
+// Load the adsbygoogle script once, lazily, so the client ID can be env-driven
+// (a static tag in index.html can't be — CRA leaves unset %VARS% as literal text).
+function ensureAdSenseScript() {
+  if (document.querySelector("script[data-adsbygoogle-loader]")) return;
+  const script = document.createElement("script");
+  script.async = true;
+  script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${AD_CLIENT}`;
+  script.crossOrigin = "anonymous";
+  script.setAttribute("data-adsbygoogle-loader", "");
+  document.head.appendChild(script);
+}
 
 const AdSlot: React.FC<AdSlotProps> = ({ slotId, style }) => {
   const { isPremium } = useAuth();
 
-  // No ads on Android (AdSense ToS), in dev, or for premium users
+  // No ads on Android (AdSense ToS), in dev, without real IDs, or for premium users
   if (Capacitor.isNativePlatform()) return null;
   if (process.env.NODE_ENV === "development") return null;
+  if (!AD_CLIENT || !slotId) return null;
   if (isPremium) return null;
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     try {
+      ensureAdSenseScript();
       ((window as any).adsbygoogle = (window as any).adsbygoogle || []).push({});
     } catch {}
   }, []);

--- a/frontend/src/components/AndroidBanner.tsx
+++ b/frontend/src/components/AndroidBanner.tsx
@@ -3,8 +3,11 @@ import { Capacitor } from "@capacitor/core";
 import { AdMob, BannerAdSize, BannerAdPosition } from "@capacitor-community/admob";
 import { useAuth } from "../context/AuthContext";
 
-// Replace with your AdMob Banner Ad Unit ID from admob.google.com
-const ADMOB_BANNER_ID = "ca-app-pub-XXXXXXXXXXXXXXXX/XXXXXXXXXX";
+// Real banner ad-unit ID comes from the build env (GHA variable); without it we
+// fall back to Google's official test banner unit, which always fills.
+const ADMOB_BANNER_ID =
+  process.env.REACT_APP_ADMOB_BANNER_ID || "ca-app-pub-3940256099942544/6300978111";
+const IS_TESTING = !process.env.REACT_APP_ADMOB_BANNER_ID;
 
 // Initialize the AdMob SDK exactly once. The native banner plugin only sets up
 // its container ViewGroup inside initialize(); calling showBanner() before that
@@ -14,7 +17,7 @@ const ADMOB_BANNER_ID = "ca-app-pub-XXXXXXXXXXXXXXXX/XXXXXXXXXX";
 let initPromise: Promise<void> | null = null;
 function ensureAdMobInitialized(): Promise<void> {
   if (!initPromise) {
-    initPromise = AdMob.initialize({ initializeForTesting: true }).catch((err) => {
+    initPromise = AdMob.initialize({ initializeForTesting: IS_TESTING }).catch((err) => {
       // Allow a retry on a later mount if initialization failed.
       initPromise = null;
       throw err;
@@ -42,7 +45,7 @@ const AndroidBanner: React.FC = () => {
           adSize: BannerAdSize.ADAPTIVE_BANNER,
           position: BannerAdPosition.BOTTOM_CENTER,
           margin: 0,
-          isTesting: false,
+          isTesting: IS_TESTING,
         });
       })
       .catch(() => {});

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -4,7 +4,8 @@ import AdSlot from "./AdSlot";
 import { T } from "../theme";
 
 const KOFI_URL = "https://ko-fi.com/oracle_singularity";
-const SLOT_ID_FOOTER = "XXXXXXXXXX"; // replace with AdSense footer ad unit slot ID
+// AdSense footer ad-unit slot ID, from the build env; AdSlot renders nothing when unset
+const SLOT_ID_FOOTER = process.env.REACT_APP_ADSENSE_SLOT_FOOTER || "";
 
 const Footer: React.FC = () => (
   <footer


### PR DESCRIPTION
## Summary
The ad code was already wired but every ID was a placeholder (the Android banner failed with `Ad failed to load: 3`). This PR makes all five ad IDs env-sourced so that once the AdMob/AdSense accounts exist, going live is just setting GitHub Actions variables — no code change.

- **AndroidBanner.tsx** — banner unit ID from `REACT_APP_ADMOB_BANNER_ID`, falling back to Google's official test banner (which actually fills); `initializeForTesting`/`isTesting` now driven together by whether a real ID is set
- **AndroidManifest.xml + build.gradle** — AdMob App ID injected via Gradle `manifestPlaceholders` from `ADMOB_APP_ID` (test App ID default)
- **AdSlot.tsx** — publisher ID from `REACT_APP_ADSENSE_CLIENT`; injects the `adsbygoogle` script at runtime (static tag removed from index.html since CRA can't safely interpolate unset vars there); renders nothing when client/slot ID is unset
- **App.tsx / Footer.tsx** — slot IDs from `REACT_APP_ADSENSE_SLOT_LEADERBOARD` / `_FOOTER`
- **deploy.yml / android-build.yml** — pass the new vars from the `production` environment; all unset today, which is safe (test ads on Android, no ads on web)

## Verification
- `npm run build` with no vars: test banner ID in bundle, no adsbygoogle in index.html, no placeholder Xs
- Build with fake IDs: all three land in the bundle
- Headless `gradlew assembleDebug`: merged manifest shows test App ID by default and a real ID when `ADMOB_APP_ID` is exported

## Follow-ups (tracked in beads, local)
- AdMob account + GHA vars (tcg-website-1nf), AdSense application + GHA vars (tcg-website-6r9), GDPR/UMP consent flow for EEA (tcg-website-lr6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)