### PR TITLE
fix(deploy): stop frontend s3 sync --delete from wiping deploy/ artifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,11 +123,14 @@ jobs:
 
       - name: Upload to S3
         run: |
+          # --exclude "deploy/*" keeps --delete from wiping the backend deploy
+          # artifacts staged under deploy/ (binaries + the out-of-band card DB)
           aws s3 sync frontend/build/ \
             s3://${{ needs.infra.outputs.frontend-bucket }}/ \
             --delete \
             --cache-control "public,max-age=31536000,immutable" \
-            --exclude "index.html"
+            --exclude "index.html" \
+            --exclude "deploy/*"
           # index.html must not be cached — it references hashed asset filenames
           aws s3 cp frontend/build/index.html \
             s3://${{ needs.infra.outputs.frontend-bucket }}/index.html \


### PR DESCRIPTION
The frontend job syncs `frontend/build/` to the bucket **root** with `--delete`, deleting every object not in the React build — including `deploy/mtg_card_db.db`, the out-of-band DB seed (staged binaries only survive because the backend job re-uploads them each run). When the EC2 instance was replaced today, the SSM deploy found neither a disk DB nor the S3 key and prod went 502 (run 27290390272, tracked as tcg-website-yhs).

One-line fix: `--exclude "deploy/*"` on the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)